### PR TITLE
Prosecutor's Office: 12 killed as a result of Armenian rocket fire on Ganja

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,1 +1,11 @@
 # Prosecutor-s-Office-12-killed-as-a-result-of-Armenian-rocket-fire-on-Ganja
+
+As a result of rocket fire on civilians in the central part of Ganja on October 17, 2020, in the midst at about 01 am 12 people were killed, more than 40 people were injured, and numerous civil infrastructure facilities and vehicles were severely damaged, the Prosecutor General's Office. told APA.
+
+It was noted that the prosecutor's office at the scene is currently carrying out investigative measures to clarify the list of victims.
+
+The public will be provided with additional information on the latest situation.
+
+ 
+
+пт, 16 окт. 2020 г. в 16:15, TRTAJANS Asif Merzili  Genja AZERBAYCAN


### PR DESCRIPTION
As a result of rocket fire on civilians in the central part of Ganja on October 17, 2020, in the midst at about 01 am 12 people were killed, more than 40 people were injured, and numerous civil infrastructure facilities and vehicles were severely damaged, the Prosecutor General's Office. told APA.

It was noted that the prosecutor's office at the scene is currently carrying out investigative measures to clarify the list of victims.

The public will be provided with additional information on the latest situation.

 

пт, 16 окт. 2020 г. в 16:15, TRTAJANS Asif Merzili  Genja AZERBAYCAN


![Genca17 10 20](https://user-images.githubusercontent.com/19478080/96334086-cc050b00-1076-11eb-975b-0fa6e6a05b67.jpg)
